### PR TITLE
fix: ctrl+k should select existing text instead of just focus

### DIFF
--- a/packages/client/src/modules/Layout/Root.tsx
+++ b/packages/client/src/modules/Layout/Root.tsx
@@ -78,7 +78,10 @@ export const Root = () => {
 		[
 			"mod+K",
 			() => {
-				isShortcuts && searchRef.current && searchRef.current.focus();
+				if (isShortcuts && searchRef.current) {
+					searchRef.current.focus();
+					searchRef.current.select();
+				}
 			},
 		],
 	]);


### PR DESCRIPTION
This pull request includes a small change to the `Root` component in the `packages/client/src/modules/Layout/Root.tsx` file. The change improves the keyboard shortcut functionality by ensuring that the search input is both focused and selected when the shortcut is triggered.

* [`packages/client/src/modules/Layout/Root.tsx`](diffhunk://#diff-db9ac5bfbb69cd5fe27716908b75de7374775a26ea8b9325646973c38819c387L81-R84): Modified the keyboard shortcut handler to focus and select the search input when the shortcut is triggered.