### PR TITLE
fix: main header should have been sticky all along

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,5 @@
 		"@versini/dev-dependencies-client": "6.0.6",
 		"@versini/dev-dependencies-types": "1.3.8"
 	},
-	"packageManager": "pnpm@9.12.0+sha512.4abf725084d7bcbafbd728bfc7bee61f2f791f977fd87542b3579dcb23504d170d46337945e4c66485cd12d588a0c0e570ed9c477e7ccdd8507cf05f3f92eaca"
+	"packageManager": "pnpm@9.12.1+sha512.e5a7e52a4183a02d5931057f7a0dbff9d5e9ce3161e33fa68ae392125b79282a8a8a470a51dfc8a0ed86221442eb2fb57019b0990ed24fab519bf0e1bc5ccfc4"
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -32,7 +32,7 @@
 		"@versini/ui-button": "1.1.10",
 		"@versini/ui-card": "1.0.9",
 		"@versini/ui-footer": "1.0.8",
-		"@versini/ui-header": "1.0.8",
+		"@versini/ui-header": "1.1.0",
 		"@versini/ui-hooks": "4.2.2",
 		"@versini/ui-icons": "1.15.1",
 		"@versini/ui-main": "1.0.8",

--- a/packages/client/src/modules/Layout/Root.tsx
+++ b/packages/client/src/modules/Layout/Root.tsx
@@ -102,7 +102,7 @@ export const Root = () => {
 
 	return (
 		<>
-			<Header mode="dark">
+			<Header mode="dark" sticky>
 				<Flexgrid alignHorizontal="space-between" alignVertical="center">
 					<FlexgridItem>
 						<h1 className="heading mb-0">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 1.0.8
         version: 1.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/ui-header':
-        specifier: 1.0.8
-        version: 1.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.1.0
+        version: 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/ui-hooks':
         specifier: 4.2.2
         version: 4.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1508,8 +1508,8 @@ packages:
       react: ^18.3.1
       react-dom: ^18.3.1
 
-  '@versini/ui-header@1.0.8':
-    resolution: {integrity: sha512-ZAVwtdmnbxPK5dpwSPQLk6gj6VtUtZqPq5X31xqHDbMlWNPFdLey/Zqo7+rBFmdroWUn9aUExoRVBvP5ncqROA==}
+  '@versini/ui-header@1.1.0':
+    resolution: {integrity: sha512-juewJKCZocK4ScZF1+2U/VK5pDaO6QforVdqO7Sd8G7Qqhz3O22R4zDoIkLksad+vV9UTCU/ZcwT308rBh5hrg==}
     peerDependencies:
       react: ^18.3.1
       react-dom: ^18.3.1
@@ -6724,7 +6724,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  '@versini/ui-header@1.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@versini/ui-header@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@tailwindcss/typography': 0.5.15(tailwindcss@3.4.13)
       '@versini/ui-private': 1.4.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
This pull request includes updates to dependencies and a minor UI enhancement. The most important changes are updating the `@versini/ui-header` package and making the header sticky in the layout.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L17-R17): Updated the `pnpm` package manager from version `9.12.0` to `9.12.1`.
* [`packages/client/package.json`](diffhunk://#diff-26d3d28d31824ef26252df77cca08d24faea8451cb8fd3ffee2000f9e496daa0L35-R35): Updated the `@versini/ui-header` dependency from version `1.0.8` to `1.1.0`.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL42-R43): Updated the `@versini/ui-header` dependency from version `1.0.8` to `1.1.0` in multiple sections to reflect the new version. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL42-R43) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1511-R1512) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6727-R6727)

UI enhancement:

* [`packages/client/src/modules/Layout/Root.tsx`](diffhunk://#diff-db9ac5bfbb69cd5fe27716908b75de7374775a26ea8b9325646973c38819c387L105-R105): Made the header sticky by adding the `sticky` prop to the `Header` component.