### PR TITLE
fix: bump non-breaking dependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
 	},
 	"devDependencies": {
 		"@node-cli/bundlesize": "4.2.1",
-		"@versini/dev-dependencies-client": "6.0.7",
-		"@versini/dev-dependencies-types": "1.3.9"
+		"@versini/dev-dependencies-client": "6.0.8",
+		"@versini/dev-dependencies-types": "1.3.10"
 	},
-	"packageManager": "pnpm@9.12.1+sha512.e5a7e52a4183a02d5931057f7a0dbff9d5e9ce3161e33fa68ae392125b79282a8a8a470a51dfc8a0ed86221442eb2fb57019b0990ed24fab519bf0e1bc5ccfc4"
+	"packageManager": "pnpm@9.12.2+sha512.22721b3a11f81661ae1ec68ce1a7b879425a1ca5b991c975b074ac220b187ce56c708fe5db69f4c962c989452eee76c82877f4ee80f474cebd61ee13461b6228"
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -27,7 +27,7 @@
 	},
 	"dependencies": {
 		"@versini/auth-provider": "7.3.3",
-		"@versini/sassysaint": "5.3.3",
+		"@versini/sassysaint": "5.3.4",
 		"@versini/ui-anchor": "1.1.10",
 		"@versini/ui-button": "1.1.10",
 		"@versini/ui-card": "1.0.9",
@@ -45,7 +45,7 @@
 		"@versini/ui-togglegroup": "1.1.0",
 		"react": "18.3.1",
 		"react-dom": "18.3.1",
-		"react-router-dom": "6.26.2",
+		"react-router-dom": "6.27.0",
 		"uuid": "10.0.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,11 +12,11 @@ importers:
         specifier: 4.2.1
         version: 4.2.1
       '@versini/dev-dependencies-client':
-        specifier: 6.0.7
-        version: 6.0.7(@microsoft/api-extractor@7.47.7(@types/node@22.7.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)(@types/node@22.7.4)(@types/react-dom@18.3.0)(@types/react@18.3.11)(encoding@0.1.13)(esbuild@0.23.0)(happy-dom@15.7.4)(jiti@1.21.0)(jsdom@25.0.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.31.4)(typescript@5.6.2)(yaml@2.5.0)
+        specifier: 6.0.8
+        version: 6.0.8(@microsoft/api-extractor@7.47.7(@types/node@22.7.5))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)(@types/node@22.7.5)(@types/react-dom@18.3.0)(@types/react@18.3.11)(encoding@0.1.13)(esbuild@0.23.0)(happy-dom@15.7.4)(jiti@1.21.0)(jsdom@25.0.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.31.4)(typescript@5.6.2)(yaml@2.5.0)
       '@versini/dev-dependencies-types':
-        specifier: 1.3.9
-        version: 1.3.9
+        specifier: 1.3.10
+        version: 1.3.10
 
   packages/client:
     dependencies:
@@ -24,8 +24,8 @@ importers:
         specifier: 7.3.3
         version: 7.3.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/sassysaint':
-        specifier: 5.3.3
-        version: 5.3.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 5.3.4
+        version: 5.3.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/ui-anchor':
         specifier: 1.1.10
         version: 1.1.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -78,8 +78,8 @@ importers:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
       react-router-dom:
-        specifier: 6.26.2
-        version: 6.26.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 6.27.0
+        version: 6.27.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       uuid:
         specifier: 10.0.0
         version: 10.0.0
@@ -984,8 +984,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@remix-run/router@1.19.2':
-    resolution: {integrity: sha512-baiMx18+IMuD1yyvOGaHM9QrVUPGGG0jC+z+IPHnRJWUAUvaKuWKyE8gjDj2rzv3sz9zOGoRSPgeBVHRhZnBlA==}
+  '@remix-run/router@1.20.0':
+    resolution: {integrity: sha512-mUnk8rPJBI9loFDZ+YzPGdeniYK+FTmRD1TMCz7ev2SNIozyKKpnGgsxO34u6Z4z/t0ITuu7voi/AshfsGsgFg==}
     engines: {node: '>=14.0.0'}
 
   '@rollup/pluginutils@5.1.0':
@@ -1077,8 +1077,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rsbuild/core@1.0.10':
-    resolution: {integrity: sha512-617N8YzDeH5vymeeOyCqK0toO9yt7s2yey49OIvW9jZqBo0IvgbkFNQf34LDLsxVzy+cpf1nGrcYWjPKhVuGfQ==}
+  '@rsbuild/core@1.0.11':
+    resolution: {integrity: sha512-kYM5gl8XbYK9DX/7uAJ+DyOgHUN8Ihk2P8buJDjIa/sbbuYixjF2KtDgcqxWDzP4oRi2NMPPe4gqzksVwVvmqw==}
     engines: {node: '>=16.7.0'}
     hasBin: true
 
@@ -1414,6 +1414,9 @@ packages:
   '@types/node@22.7.4':
     resolution: {integrity: sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==}
 
+  '@types/node@22.7.5':
+    resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
+
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
@@ -1459,17 +1462,17 @@ packages:
       react: ^18.3.1
       react-dom: ^18.3.1
 
-  '@versini/dev-dependencies-client@6.0.7':
-    resolution: {integrity: sha512-k5aVcDlnav5++FY4YEzTes90n19IfhOv+a7KTTsqR/4Jips8j9KYbOgCSzZ/wr/dNfceY7Q+hrvpDwxChcBIaA==}
+  '@versini/dev-dependencies-client@6.0.8':
+    resolution: {integrity: sha512-bhjHLLH/bWJw2zE+uKvIFfTqVmk1gfHQEuvjegwj/Q0M9HTiNrC84tUNN7HZAny+r9QvFZEqcdZj+GOrtQ6Wlg==}
 
-  '@versini/dev-dependencies-common@4.1.9':
-    resolution: {integrity: sha512-gQiAbzwcCLAfhfQji5fvDkM0J1cQf6AUttE8zosL8ad77IurMS+MURMWK4k1+GqJFULxdxdV/1v/eYZCD5iupw==}
+  '@versini/dev-dependencies-common@4.1.10':
+    resolution: {integrity: sha512-/5w6ck/e4KtcXSMtcww9WV2N6k0O6EN3LovUH55FVsZxm5FysEMp8b7IwRRDkqdhM2RLXNlPzK3YnuJD+w2F5A==}
 
-  '@versini/dev-dependencies-types@1.3.9':
-    resolution: {integrity: sha512-9YbxGpSuMJw3Va6XfH5XlwztGnuTm/9ljA5EScgVAU14w8Dtqi65SZXMbs77YtJMSXOqdZkLY3TWK4QOgaiPUg==}
+  '@versini/dev-dependencies-types@1.3.10':
+    resolution: {integrity: sha512-/b709s6yM6YGdkRX1UaPM3GHUuqhb35kEoVrprzx+dWDKxpKitRjE6na+yBj/AUHG/9UFk42QJolV031DRTq/A==}
 
-  '@versini/sassysaint@5.3.3':
-    resolution: {integrity: sha512-KrQ2fCoYo7/dwANfq93G3xgTaSg+uoqsCEOXYMFk3S+ydjNTh/yERZ5g1F0oZ/2D8CTyKn3i5EAppYHGIRZ5lw==}
+  '@versini/sassysaint@5.3.4':
+    resolution: {integrity: sha512-I4kGCwk/GRyzMed3KI4VUE6ZrcZeJT0JT4B7dEuh66rvmsQihoXXgWeIxag7ocSY/QNFzDW1/9KDIv8K5Lt5Dg==}
     peerDependencies:
       react: 18.3.1
       react-dom: 18.3.1
@@ -4167,15 +4170,15 @@ packages:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
 
-  react-router-dom@6.26.2:
-    resolution: {integrity: sha512-z7YkaEW0Dy35T3/QKPYB1LjMK2R1fxnHO8kWpUMTBdfVzZrWOiY9a7CtN8HqdWtDUWd5FY6Dl8HFsqVwH4uOtQ==}
+  react-router-dom@6.27.0:
+    resolution: {integrity: sha512-+bvtFWMC0DgAFrfKXKG9Fc+BcXWRUO1aJIihbB79xaeq0v5UzfvnM5houGUm1Y461WVRcgAQ+Clh5rdb1eCx4g==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  react-router@6.26.2:
-    resolution: {integrity: sha512-tvN1iuT03kHgOFnLPfLJ8V95eijteveqdOSk+srqfePtQvqCExB8eHOYnlilbOcyJyKnYkr1vJvf7YqotAJu1A==}
+  react-router@6.27.0:
+    resolution: {integrity: sha512-YA+HGZXz4jaAkVoYBE98VQl+nVzI+cVI2Oj/06F5ZM+0u3TgedN9Y9kmMRo2mnkSK2nCpNQn0DVob4HCsY/WLw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
@@ -4850,6 +4853,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@5.6.3:
+    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   ufo@1.4.0:
     resolution: {integrity: sha512-Hhy+BhRBleFjpJ2vchUNN40qgkh0366FWJGqVLYBHev0vpHTrXSA0ryT+74UiW6KWsldNurQMKGqCm1M2zBciQ==}
 
@@ -5482,7 +5490,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.7.4
+      '@types/node': 22.7.5
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -5591,23 +5599,23 @@ snapshots:
       - supports-color
       - typescript
 
-  '@microsoft/api-extractor-model@7.29.6(@types/node@22.7.4)':
+  '@microsoft/api-extractor-model@7.29.6(@types/node@22.7.5)':
     dependencies:
       '@microsoft/tsdoc': 0.15.0
       '@microsoft/tsdoc-config': 0.17.0
-      '@rushstack/node-core-library': 5.7.0(@types/node@22.7.4)
+      '@rushstack/node-core-library': 5.7.0(@types/node@22.7.5)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.47.7(@types/node@22.7.4)':
+  '@microsoft/api-extractor@7.47.7(@types/node@22.7.5)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.29.6(@types/node@22.7.4)
+      '@microsoft/api-extractor-model': 7.29.6(@types/node@22.7.5)
       '@microsoft/tsdoc': 0.15.0
       '@microsoft/tsdoc-config': 0.17.0
-      '@rushstack/node-core-library': 5.7.0(@types/node@22.7.4)
+      '@rushstack/node-core-library': 5.7.0(@types/node@22.7.5)
       '@rushstack/rig-package': 0.5.3
-      '@rushstack/terminal': 0.14.0(@types/node@22.7.4)
-      '@rushstack/ts-command-line': 4.22.6(@types/node@22.7.4)
+      '@rushstack/terminal': 0.14.0(@types/node@22.7.5)
+      '@rushstack/ts-command-line': 4.22.6(@types/node@22.7.5)
       lodash: 4.17.21
       minimatch: 3.0.5
       resolve: 1.22.8
@@ -6072,7 +6080,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
 
-  '@remix-run/router@1.19.2': {}
+  '@remix-run/router@1.20.0': {}
 
   '@rollup/pluginutils@5.1.0(rollup@4.24.0)':
     dependencies:
@@ -6130,7 +6138,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.24.0':
     optional: true
 
-  '@rsbuild/core@1.0.10':
+  '@rsbuild/core@1.0.11':
     dependencies:
       '@rspack/core': 1.0.8(@swc/helpers@0.5.13)
       '@rspack/lite-tapable': 1.0.1
@@ -6139,13 +6147,13 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  '@rsbuild/plugin-react@1.0.3(@rsbuild/core@1.0.10)':
+  '@rsbuild/plugin-react@1.0.3(@rsbuild/core@1.0.11)':
     dependencies:
-      '@rsbuild/core': 1.0.10
+      '@rsbuild/core': 1.0.11
       '@rspack/plugin-react-refresh': 1.0.0(react-refresh@0.14.2)
       react-refresh: 0.14.2
 
-  '@rsbuild/plugin-type-check@1.0.1(@rsbuild/core@1.0.10)(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.23.0)(typescript@5.6.2)':
+  '@rsbuild/plugin-type-check@1.0.1(@rsbuild/core@1.0.11)(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.23.0)(typescript@5.6.2)':
     dependencies:
       deepmerge: 4.3.1
       fork-ts-checker-webpack-plugin: 9.0.2(typescript@5.6.2)(webpack@5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.23.0))
@@ -6153,7 +6161,7 @@ snapshots:
       reduce-configs: 1.0.0
       webpack: 5.94.0(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.23.0)
     optionalDependencies:
-      '@rsbuild/core': 1.0.10
+      '@rsbuild/core': 1.0.11
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -6218,7 +6226,7 @@ snapshots:
     optionalDependencies:
       react-refresh: 0.14.2
 
-  '@rushstack/node-core-library@5.7.0(@types/node@22.7.4)':
+  '@rushstack/node-core-library@5.7.0(@types/node@22.7.5)':
     dependencies:
       ajv: 8.13.0
       ajv-draft-04: 1.0.0(ajv@8.13.0)
@@ -6229,23 +6237,23 @@ snapshots:
       resolve: 1.22.8
       semver: 7.5.4
     optionalDependencies:
-      '@types/node': 22.7.4
+      '@types/node': 22.7.5
 
   '@rushstack/rig-package@0.5.3':
     dependencies:
       resolve: 1.22.8
       strip-json-comments: 3.1.1
 
-  '@rushstack/terminal@0.14.0(@types/node@22.7.4)':
+  '@rushstack/terminal@0.14.0(@types/node@22.7.5)':
     dependencies:
-      '@rushstack/node-core-library': 5.7.0(@types/node@22.7.4)
+      '@rushstack/node-core-library': 5.7.0(@types/node@22.7.5)
       supports-color: 8.1.1
     optionalDependencies:
-      '@types/node': 22.7.4
+      '@types/node': 22.7.5
 
-  '@rushstack/ts-command-line@4.22.6(@types/node@22.7.4)':
+  '@rushstack/ts-command-line@4.22.6(@types/node@22.7.5)':
     dependencies:
-      '@rushstack/terminal': 0.14.0(@types/node@22.7.4)
+      '@rushstack/terminal': 0.14.0(@types/node@22.7.5)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -6404,13 +6412,13 @@ snapshots:
   '@types/body-parser@1.19.5':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.7.4
+      '@types/node': 22.7.5
 
   '@types/bytes@3.1.4': {}
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.7.4
+      '@types/node': 22.7.5
 
   '@types/culori@2.1.1': {}
 
@@ -6418,7 +6426,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.17.43':
     dependencies:
-      '@types/node': 22.7.4
+      '@types/node': 22.7.5
       '@types/qs': 6.9.11
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -6433,7 +6441,7 @@ snapshots:
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 22.7.4
+      '@types/node': 22.7.5
 
   '@types/http-errors@2.0.4': {}
 
@@ -6456,7 +6464,7 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 22.7.4
+      '@types/node': 22.7.5
 
   '@types/lodash-es@4.17.12':
     dependencies:
@@ -6474,9 +6482,13 @@ snapshots:
 
   '@types/node-notifier@8.0.5':
     dependencies:
-      '@types/node': 22.7.4
+      '@types/node': 22.7.5
 
   '@types/node@22.7.4':
+    dependencies:
+      undici-types: 6.19.8
+
+  '@types/node@22.7.5':
     dependencies:
       undici-types: 6.19.8
 
@@ -6500,13 +6512,13 @@ snapshots:
   '@types/send@0.17.4':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 22.7.4
+      '@types/node': 22.7.5
 
   '@types/serve-static@1.15.5':
     dependencies:
       '@types/http-errors': 2.0.4
       '@types/mime': 3.0.4
-      '@types/node': 22.7.4
+      '@types/node': 22.7.5
 
   '@types/stack-utils@2.0.3': {}
 
@@ -6533,17 +6545,17 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       uuid: 10.0.0
 
-  '@versini/dev-dependencies-client@6.0.7(@microsoft/api-extractor@7.47.7(@types/node@22.7.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)(@types/node@22.7.4)(@types/react-dom@18.3.0)(@types/react@18.3.11)(encoding@0.1.13)(esbuild@0.23.0)(happy-dom@15.7.4)(jiti@1.21.0)(jsdom@25.0.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.31.4)(typescript@5.6.2)(yaml@2.5.0)':
+  '@versini/dev-dependencies-client@6.0.8(@microsoft/api-extractor@7.47.7(@types/node@22.7.5))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)(@types/node@22.7.5)(@types/react-dom@18.3.0)(@types/react@18.3.11)(encoding@0.1.13)(esbuild@0.23.0)(happy-dom@15.7.4)(jiti@1.21.0)(jsdom@25.0.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.31.4)(typescript@5.6.2)(yaml@2.5.0)':
     dependencies:
-      '@rsbuild/core': 1.0.10
-      '@rsbuild/plugin-react': 1.0.3(@rsbuild/core@1.0.10)
-      '@rsbuild/plugin-type-check': 1.0.1(@rsbuild/core@1.0.10)(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.23.0)(typescript@5.6.2)
+      '@rsbuild/core': 1.0.11
+      '@rsbuild/plugin-react': 1.0.3(@rsbuild/core@1.0.11)
+      '@rsbuild/plugin-type-check': 1.0.1(@rsbuild/core@1.0.11)(@swc/core@1.7.26(@swc/helpers@0.5.13))(esbuild@0.23.0)(typescript@5.6.2)
       '@testing-library/dom': 10.4.0
       '@testing-library/jest-dom': 6.5.0
       '@testing-library/react': 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.0)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
-      '@versini/dev-dependencies-common': 4.1.9
-      '@vitejs/plugin-react-swc': 3.7.1(@swc/helpers@0.5.13)(vite@5.4.8(@types/node@22.7.4)(terser@5.31.4))
+      '@versini/dev-dependencies-common': 4.1.10
+      '@vitejs/plugin-react-swc': 3.7.1(@swc/helpers@0.5.13)(vite@5.4.8(@types/node@22.7.5)(terser@5.31.4))
       '@vitest/coverage-v8': 2.1.2(vitest@2.1.2)
       '@vitest/ui': 2.1.2(vitest@2.1.2)
       autoprefixer: 10.4.20(postcss@8.4.47)
@@ -6560,11 +6572,11 @@ snapshots:
       rimraf: 6.0.1
       rollup: 4.24.0
       tailwindcss: 3.4.13
-      tsup: 8.3.0(@microsoft/api-extractor@7.47.7(@types/node@22.7.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(jiti@1.21.0)(postcss@8.4.47)(typescript@5.6.2)(yaml@2.5.0)
-      vite: 5.4.8(@types/node@22.7.4)(terser@5.31.4)
-      vite-plugin-dts: 4.2.3(@types/node@22.7.4)(rollup@4.24.0)(typescript@5.6.2)(vite@5.4.8(@types/node@22.7.4)(terser@5.31.4))
-      vite-plugin-lib-inject-css: 2.1.1(vite@5.4.8(@types/node@22.7.4)(terser@5.31.4))
-      vitest: 2.1.2(@types/node@22.7.4)(@vitest/ui@2.1.2)(happy-dom@15.7.4)(jsdom@25.0.1)(terser@5.31.4)
+      tsup: 8.3.0(@microsoft/api-extractor@7.47.7(@types/node@22.7.5))(@swc/core@1.7.26(@swc/helpers@0.5.13))(jiti@1.21.0)(postcss@8.4.47)(typescript@5.6.2)(yaml@2.5.0)
+      vite: 5.4.8(@types/node@22.7.5)(terser@5.31.4)
+      vite-plugin-dts: 4.2.3(@types/node@22.7.5)(rollup@4.24.0)(typescript@5.6.2)(vite@5.4.8(@types/node@22.7.5)(terser@5.31.4))
+      vite-plugin-lib-inject-css: 2.1.1(vite@5.4.8(@types/node@22.7.5)(terser@5.31.4))
+      vitest: 2.1.2(@types/node@22.7.5)(@vitest/ui@2.1.2)(happy-dom@15.7.4)(jsdom@25.0.1)(terser@5.31.4)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@ianvs/prettier-plugin-sort-imports'
@@ -6620,7 +6632,7 @@ snapshots:
       - webpack-cli
       - yaml
 
-  '@versini/dev-dependencies-common@4.1.9':
+  '@versini/dev-dependencies-common@4.1.10':
     dependencies:
       '@biomejs/biome': 1.9.3
       chokidar: 4.0.1
@@ -6630,14 +6642,14 @@ snapshots:
       glob: 11.0.0
       happy-dom: 15.7.4
       jsdom: 25.0.1
-      typescript: 5.6.2
+      typescript: 5.6.3
     transitivePeerDependencies:
       - bufferutil
       - canvas
       - supports-color
       - utf-8-validate
 
-  '@versini/dev-dependencies-types@1.3.9':
+  '@versini/dev-dependencies-types@1.3.10':
     dependencies:
       '@simplewebauthn/types': 10.0.0
       '@types/bytes': 3.1.4
@@ -6646,14 +6658,14 @@ snapshots:
       '@types/fs-extra': 11.0.4
       '@types/jest': 29.5.13
       '@types/lodash-es': 4.17.12
-      '@types/node': 22.7.4
+      '@types/node': 22.7.5
       '@types/node-notifier': 8.0.5
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.0
       '@types/uuid': 10.0.0
       '@types/yargs': 17.0.33
 
-  '@versini/sassysaint@5.3.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@versini/sassysaint@5.3.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@versini/ui-hooks': 4.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
@@ -6843,10 +6855,10 @@ snapshots:
       - '@types/react-dom'
       - ts-node
 
-  '@vitejs/plugin-react-swc@3.7.1(@swc/helpers@0.5.13)(vite@5.4.8(@types/node@22.7.4)(terser@5.31.4))':
+  '@vitejs/plugin-react-swc@3.7.1(@swc/helpers@0.5.13)(vite@5.4.8(@types/node@22.7.5)(terser@5.31.4))':
     dependencies:
       '@swc/core': 1.7.26(@swc/helpers@0.5.13)
-      vite: 5.4.8(@types/node@22.7.4)(terser@5.31.4)
+      vite: 5.4.8(@types/node@22.7.5)(terser@5.31.4)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -6864,7 +6876,7 @@ snapshots:
       std-env: 3.7.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.2(@types/node@22.7.4)(@vitest/ui@2.1.2)(happy-dom@15.7.4)(jsdom@25.0.1)(terser@5.31.4)
+      vitest: 2.1.2(@types/node@22.7.5)(@vitest/ui@2.1.2)(happy-dom@15.7.4)(jsdom@25.0.1)(terser@5.31.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -6875,13 +6887,13 @@ snapshots:
       chai: 5.1.1
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.2(@vitest/spy@2.1.2)(vite@5.4.8(@types/node@22.7.4)(terser@5.31.4))':
+  '@vitest/mocker@2.1.2(@vitest/spy@2.1.2)(vite@5.4.8(@types/node@22.7.5)(terser@5.31.4))':
     dependencies:
       '@vitest/spy': 2.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.11
     optionalDependencies:
-      vite: 5.4.8(@types/node@22.7.4)(terser@5.31.4)
+      vite: 5.4.8(@types/node@22.7.5)(terser@5.31.4)
 
   '@vitest/pretty-format@2.1.2':
     dependencies:
@@ -6911,7 +6923,7 @@ snapshots:
       sirv: 2.0.4
       tinyglobby: 0.2.6
       tinyrainbow: 1.2.0
-      vitest: 2.1.2(@types/node@22.7.4)(@vitest/ui@2.1.2)(happy-dom@15.7.4)(jsdom@25.0.1)(terser@5.31.4)
+      vitest: 2.1.2(@types/node@22.7.5)(@vitest/ui@2.1.2)(happy-dom@15.7.4)(jsdom@25.0.1)(terser@5.31.4)
 
   '@vitest/utils@2.1.2':
     dependencies:
@@ -8600,7 +8612,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.7.4
+      '@types/node': 22.7.5
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -9685,16 +9697,16 @@ snapshots:
 
   react-refresh@0.14.2: {}
 
-  react-router-dom@6.26.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router-dom@6.27.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.19.2
+      '@remix-run/router': 1.20.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-router: 6.26.2(react@18.3.1)
+      react-router: 6.27.0(react@18.3.1)
 
-  react-router@6.26.2(react@18.3.1):
+  react-router@6.27.0(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.19.2
+      '@remix-run/router': 1.20.0
       react: 18.3.1
 
   react@18.3.1:
@@ -10344,7 +10356,7 @@ snapshots:
 
   tslib@2.6.2: {}
 
-  tsup@8.3.0(@microsoft/api-extractor@7.47.7(@types/node@22.7.4))(@swc/core@1.7.26(@swc/helpers@0.5.13))(jiti@1.21.0)(postcss@8.4.47)(typescript@5.6.2)(yaml@2.5.0):
+  tsup@8.3.0(@microsoft/api-extractor@7.47.7(@types/node@22.7.5))(@swc/core@1.7.26(@swc/helpers@0.5.13))(jiti@1.21.0)(postcss@8.4.47)(typescript@5.6.2)(yaml@2.5.0):
     dependencies:
       bundle-require: 5.0.0(esbuild@0.23.0)
       cac: 6.7.14
@@ -10363,7 +10375,7 @@ snapshots:
       tinyglobby: 0.2.6
       tree-kill: 1.2.2
     optionalDependencies:
-      '@microsoft/api-extractor': 7.47.7(@types/node@22.7.4)
+      '@microsoft/api-extractor': 7.47.7(@types/node@22.7.5)
       '@swc/core': 1.7.26(@swc/helpers@0.5.13)
       postcss: 8.4.47
       typescript: 5.6.2
@@ -10431,6 +10443,8 @@ snapshots:
 
   typescript@5.6.2: {}
 
+  typescript@5.6.3: {}
+
   ufo@1.4.0: {}
 
   uglify-js@3.17.4:
@@ -10484,12 +10498,12 @@ snapshots:
 
   validate-npm-package-name@5.0.1: {}
 
-  vite-node@2.1.2(@types/node@22.7.4)(terser@5.31.4):
+  vite-node@2.1.2(@types/node@22.7.5)(terser@5.31.4):
     dependencies:
       cac: 6.7.14
       debug: 4.3.6(supports-color@5.5.0)
       pathe: 1.1.2
-      vite: 5.4.8(@types/node@22.7.4)(terser@5.31.4)
+      vite: 5.4.8(@types/node@22.7.5)(terser@5.31.4)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -10501,9 +10515,9 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-dts@4.2.3(@types/node@22.7.4)(rollup@4.24.0)(typescript@5.6.2)(vite@5.4.8(@types/node@22.7.4)(terser@5.31.4)):
+  vite-plugin-dts@4.2.3(@types/node@22.7.5)(rollup@4.24.0)(typescript@5.6.2)(vite@5.4.8(@types/node@22.7.5)(terser@5.31.4)):
     dependencies:
-      '@microsoft/api-extractor': 7.47.7(@types/node@22.7.4)
+      '@microsoft/api-extractor': 7.47.7(@types/node@22.7.5)
       '@rollup/pluginutils': 5.1.0(rollup@4.24.0)
       '@volar/typescript': 2.4.5
       '@vue/language-core': 2.1.6(typescript@5.6.2)
@@ -10514,33 +10528,33 @@ snapshots:
       magic-string: 0.30.11
       typescript: 5.6.2
     optionalDependencies:
-      vite: 5.4.8(@types/node@22.7.4)(terser@5.31.4)
+      vite: 5.4.8(@types/node@22.7.5)(terser@5.31.4)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite-plugin-lib-inject-css@2.1.1(vite@5.4.8(@types/node@22.7.4)(terser@5.31.4)):
+  vite-plugin-lib-inject-css@2.1.1(vite@5.4.8(@types/node@22.7.5)(terser@5.31.4)):
     dependencies:
       '@ast-grep/napi': 0.22.4
       magic-string: 0.30.11
       picocolors: 1.1.0
-      vite: 5.4.8(@types/node@22.7.4)(terser@5.31.4)
+      vite: 5.4.8(@types/node@22.7.5)(terser@5.31.4)
 
-  vite@5.4.8(@types/node@22.7.4)(terser@5.31.4):
+  vite@5.4.8(@types/node@22.7.5)(terser@5.31.4):
     dependencies:
       esbuild: 0.21.4
       postcss: 8.4.47
       rollup: 4.24.0
     optionalDependencies:
-      '@types/node': 22.7.4
+      '@types/node': 22.7.5
       fsevents: 2.3.3
       terser: 5.31.4
 
-  vitest@2.1.2(@types/node@22.7.4)(@vitest/ui@2.1.2)(happy-dom@15.7.4)(jsdom@25.0.1)(terser@5.31.4):
+  vitest@2.1.2(@types/node@22.7.5)(@vitest/ui@2.1.2)(happy-dom@15.7.4)(jsdom@25.0.1)(terser@5.31.4):
     dependencies:
       '@vitest/expect': 2.1.2
-      '@vitest/mocker': 2.1.2(@vitest/spy@2.1.2)(vite@5.4.8(@types/node@22.7.4)(terser@5.31.4))
+      '@vitest/mocker': 2.1.2(@vitest/spy@2.1.2)(vite@5.4.8(@types/node@22.7.5)(terser@5.31.4))
       '@vitest/pretty-format': 2.1.2
       '@vitest/runner': 2.1.2
       '@vitest/snapshot': 2.1.2
@@ -10555,11 +10569,11 @@ snapshots:
       tinyexec: 0.3.0
       tinypool: 1.0.1
       tinyrainbow: 1.2.0
-      vite: 5.4.8(@types/node@22.7.4)(terser@5.31.4)
-      vite-node: 2.1.2(@types/node@22.7.4)(terser@5.31.4)
+      vite: 5.4.8(@types/node@22.7.5)(terser@5.31.4)
+      vite-node: 2.1.2(@types/node@22.7.5)(terser@5.31.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.7.4
+      '@types/node': 22.7.5
       '@vitest/ui': 2.1.2(vitest@2.1.2)
       happy-dom: 15.7.4
       jsdom: 25.0.1


### PR DESCRIPTION
This pull request includes various updates to dependencies and dev-dependencies across multiple files, primarily focusing on version upgrades to ensure compatibility and security. The most important changes include updates to `package.json`, `packages/client/package.json`, and `pnpm-lock.yaml`.

### Dependency Updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L14-R17): Updated `@versini/dev-dependencies-client` to `6.0.8` and `@versini/dev-dependencies-types` to `1.3.10`. Also updated `pnpm` to `9.12.2`.
* [`packages/client/package.json`](diffhunk://#diff-26d3d28d31824ef26252df77cca08d24faea8451cb8fd3ffee2000f9e496daa0L30-R30): Updated `@versini/sassysaint` to `5.3.4` and `react-router-dom` to `6.27.0`. [[1]](diffhunk://#diff-26d3d28d31824ef26252df77cca08d24faea8451cb8fd3ffee2000f9e496daa0L30-R30) [[2]](diffhunk://#diff-26d3d28d31824ef26252df77cca08d24faea8451cb8fd3ffee2000f9e496daa0L48-R48)

