### PR TITLE
fix: bump non-breaking dependencies to latest

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -27,7 +27,7 @@
 	},
 	"dependencies": {
 		"@versini/auth-provider": "7.3.3",
-		"@versini/sassysaint": "5.3.4",
+		"@versini/sassysaint": "5.3.5",
 		"@versini/ui-anchor": "1.1.10",
 		"@versini/ui-button": "1.1.10",
 		"@versini/ui-card": "1.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: 7.3.3
         version: 7.3.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/sassysaint':
-        specifier: 5.3.4
-        version: 5.3.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 5.3.5
+        version: 5.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/ui-anchor':
         specifier: 1.1.10
         version: 1.1.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1471,8 +1471,8 @@ packages:
   '@versini/dev-dependencies-types@1.3.10':
     resolution: {integrity: sha512-/b709s6yM6YGdkRX1UaPM3GHUuqhb35kEoVrprzx+dWDKxpKitRjE6na+yBj/AUHG/9UFk42QJolV031DRTq/A==}
 
-  '@versini/sassysaint@5.3.4':
-    resolution: {integrity: sha512-I4kGCwk/GRyzMed3KI4VUE6ZrcZeJT0JT4B7dEuh66rvmsQihoXXgWeIxag7ocSY/QNFzDW1/9KDIv8K5Lt5Dg==}
+  '@versini/sassysaint@5.3.5':
+    resolution: {integrity: sha512-zOYBoXkS3YAur0TPEJTBvraL4BKOGPpCghj6+lWcJ1De3NYZrI7jD0K7lXzN1MPhVMcssDvK/mNY8rxSNhRVBg==}
     peerDependencies:
       react: 18.3.1
       react-dom: 18.3.1
@@ -4630,6 +4630,11 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
+  tailwindcss@3.4.14:
+    resolution: {integrity: sha512-IcSvOcTRcUtQQ7ILQL5quRDg7Xs93PdJEk1ZLbhhvJc7uj/OAhYOnruEiwnGgBvUtaUAJ8/mhSw1o8L2jCiENA==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
   tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
@@ -6665,13 +6670,13 @@ snapshots:
       '@types/uuid': 10.0.0
       '@types/yargs': 17.0.33
 
-  '@versini/sassysaint@5.3.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@versini/sassysaint@5.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@versini/ui-hooks': 4.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      tailwindcss: 3.4.13
+      tailwindcss: 3.4.14
     transitivePeerDependencies:
       - ts-node
 
@@ -10196,6 +10201,33 @@ snapshots:
   tabbable@6.2.0: {}
 
   tailwindcss@3.4.13:
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.6.0
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.2
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.0
+      lilconfig: 2.1.0
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.1.0
+      postcss: 8.4.47
+      postcss-import: 15.1.0(postcss@8.4.47)
+      postcss-js: 4.0.1(postcss@8.4.47)
+      postcss-load-config: 4.0.2(postcss@8.4.47)
+      postcss-nested: 6.0.1(postcss@8.4.47)
+      postcss-selector-parser: 6.0.15
+      resolve: 1.22.8
+      sucrase: 3.35.0
+    transitivePeerDependencies:
+      - ts-node
+
+  tailwindcss@3.4.14:
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2


### PR DESCRIPTION
This pull request includes a minor version update to a dependency in the `packages/client/package.json` file.

* [`packages/client/package.json`](diffhunk://#diff-26d3d28d31824ef26252df77cca08d24faea8451cb8fd3ffee2000f9e496daa0L30-R30): Updated `@versini/sassysaint` dependency from version `5.3.4` to `5.3.5`.