### PR TITLE
fix: bump non-breaking dependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,5 @@
 		"@versini/dev-dependencies-client": "6.0.8",
 		"@versini/dev-dependencies-types": "1.3.10"
 	},
-	"packageManager": "pnpm@9.12.2+sha512.22721b3a11f81661ae1ec68ce1a7b879425a1ca5b991c975b074ac220b187ce56c708fe5db69f4c962c989452eee76c82877f4ee80f474cebd61ee13461b6228"
+	"packageManager": "pnpm@9.13.2+sha512.88c9c3864450350e65a33587ab801acf946d7c814ed1134da4a924f6df5a2120fd36b46aab68f7cd1d413149112d53c7db3a4136624cfd00ff1846a0c6cef48a"
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -23,29 +23,29 @@
 		"test:watch": "vitest"
 	},
 	"devDependencies": {
-		"@versini/ui-styles": "1.11.0"
+		"@versini/ui-styles": "1.11.1"
 	},
 	"dependencies": {
 		"@versini/auth-provider": "7.3.3",
-		"@versini/sassysaint": "5.3.5",
-		"@versini/ui-anchor": "1.1.10",
-		"@versini/ui-button": "1.1.10",
-		"@versini/ui-card": "1.0.9",
-		"@versini/ui-footer": "1.0.8",
-		"@versini/ui-header": "1.1.0",
+		"@versini/sassysaint": "5.3.7",
+		"@versini/ui-anchor": "1.1.11",
+		"@versini/ui-button": "1.1.11",
+		"@versini/ui-card": "1.0.10",
+		"@versini/ui-footer": "1.0.9",
+		"@versini/ui-header": "1.1.1",
 		"@versini/ui-hooks": "4.2.2",
-		"@versini/ui-icons": "1.15.1",
-		"@versini/ui-main": "1.0.8",
-		"@versini/ui-menu": "1.1.0",
-		"@versini/ui-panel": "1.0.14",
-		"@versini/ui-system": "1.4.19",
-		"@versini/ui-table": "1.0.13",
-		"@versini/ui-textarea": "1.0.8",
-		"@versini/ui-textinput": "1.2.1",
-		"@versini/ui-togglegroup": "1.1.0",
+		"@versini/ui-icons": "1.15.2",
+		"@versini/ui-main": "1.0.9",
+		"@versini/ui-menu": "1.1.1",
+		"@versini/ui-panel": "1.0.15",
+		"@versini/ui-system": "1.4.20",
+		"@versini/ui-table": "1.1.0",
+		"@versini/ui-textarea": "1.0.9",
+		"@versini/ui-textinput": "1.2.2",
+		"@versini/ui-togglegroup": "1.1.1",
 		"react": "18.3.1",
 		"react-dom": "18.3.1",
-		"react-router-dom": "6.27.0",
+		"react-router-dom": "6.28.0",
 		"uuid": "10.0.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 4.2.1
       '@versini/dev-dependencies-client':
         specifier: 6.0.8
-        version: 6.0.8(@microsoft/api-extractor@7.47.7(@types/node@22.7.5))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)(@types/node@22.7.5)(@types/react-dom@18.3.0)(@types/react@18.3.11)(encoding@0.1.13)(esbuild@0.23.0)(happy-dom@15.7.4)(jiti@1.21.0)(jsdom@25.0.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.31.4)(typescript@5.6.2)(yaml@2.5.0)
+        version: 6.0.8(@microsoft/api-extractor@7.47.7(@types/node@22.7.5))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)(@types/node@22.7.5)(@types/react-dom@18.3.0)(@types/react@18.3.11)(encoding@0.1.13)(esbuild@0.23.0)(happy-dom@15.7.4)(jiti@1.21.6)(jsdom@25.0.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.31.4)(typescript@5.6.2)(yaml@2.5.0)
       '@versini/dev-dependencies-types':
         specifier: 1.3.10
         version: 1.3.10
@@ -24,53 +24,53 @@ importers:
         specifier: 7.3.3
         version: 7.3.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/sassysaint':
-        specifier: 5.3.5
-        version: 5.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 5.3.7
+        version: 5.3.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/ui-anchor':
-        specifier: 1.1.10
-        version: 1.1.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.1.11
+        version: 1.1.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/ui-button':
-        specifier: 1.1.10
-        version: 1.1.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.1.11
+        version: 1.1.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/ui-card':
+        specifier: 1.0.10
+        version: 1.0.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@versini/ui-footer':
         specifier: 1.0.9
         version: 1.0.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@versini/ui-footer':
-        specifier: 1.0.8
-        version: 1.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/ui-header':
-        specifier: 1.1.0
-        version: 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.1.1
+        version: 1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/ui-hooks':
         specifier: 4.2.2
         version: 4.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/ui-icons':
-        specifier: 1.15.1
-        version: 1.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.15.2
+        version: 1.15.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/ui-main':
-        specifier: 1.0.8
-        version: 1.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.0.9
+        version: 1.0.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/ui-menu':
+        specifier: 1.1.1
+        version: 1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@versini/ui-panel':
+        specifier: 1.0.15
+        version: 1.0.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@versini/ui-system':
+        specifier: 1.4.20
+        version: 1.4.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@versini/ui-table':
         specifier: 1.1.0
         version: 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@versini/ui-panel':
-        specifier: 1.0.14
-        version: 1.0.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@versini/ui-system':
-        specifier: 1.4.19
-        version: 1.4.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@versini/ui-table':
-        specifier: 1.0.13
-        version: 1.0.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/ui-textarea':
-        specifier: 1.0.8
-        version: 1.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.0.9
+        version: 1.0.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/ui-textinput':
-        specifier: 1.2.1
-        version: 1.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.2.2
+        version: 1.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/ui-togglegroup':
-        specifier: 1.1.0
-        version: 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.1.1
+        version: 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -78,15 +78,15 @@ importers:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
       react-router-dom:
-        specifier: 6.27.0
-        version: 6.27.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 6.28.0
+        version: 6.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       uuid:
         specifier: 10.0.0
         version: 10.0.0
     devDependencies:
       '@versini/ui-styles':
-        specifier: 1.11.0
-        version: 1.11.0
+        specifier: 1.11.1
+        version: 1.11.1
 
 packages:
 
@@ -536,8 +536,8 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@floating-ui/react@0.26.24':
-    resolution: {integrity: sha512-2ly0pCkZIGEQUq5H8bBK0XJmc1xIK/RM3tvVzY3GBER7IOD1UgmC2Y2tjj4AuS+TC+vTE1KJv2053290jua0Sw==}
+  '@floating-ui/react@0.26.28':
+    resolution: {integrity: sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
@@ -984,8 +984,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@remix-run/router@1.20.0':
-    resolution: {integrity: sha512-mUnk8rPJBI9loFDZ+YzPGdeniYK+FTmRD1TMCz7ev2SNIozyKKpnGgsxO34u6Z4z/t0ITuu7voi/AshfsGsgFg==}
+  '@remix-run/router@1.21.0':
+    resolution: {integrity: sha512-xfSkCAchbdG5PnbrKqFWwia4Bi61nH+wm8wLEqfHDyp7Y3dZzgqS2itV8i4gAq9pC2HsTpwyBC6Ds8VHZ96JlA==}
     engines: {node: '>=14.0.0'}
 
   '@rollup/pluginutils@5.1.0':
@@ -1471,38 +1471,38 @@ packages:
   '@versini/dev-dependencies-types@1.3.10':
     resolution: {integrity: sha512-/b709s6yM6YGdkRX1UaPM3GHUuqhb35kEoVrprzx+dWDKxpKitRjE6na+yBj/AUHG/9UFk42QJolV031DRTq/A==}
 
-  '@versini/sassysaint@5.3.5':
-    resolution: {integrity: sha512-zOYBoXkS3YAur0TPEJTBvraL4BKOGPpCghj6+lWcJ1De3NYZrI7jD0K7lXzN1MPhVMcssDvK/mNY8rxSNhRVBg==}
+  '@versini/sassysaint@5.3.7':
+    resolution: {integrity: sha512-oOkcrkoUkjVUVq1j9Z7ukDEPjgylbqgqILsHNuPMzndhIsghLq0zK7YLQprFzVoSoVCkEusMmJfme6d46gcTpA==}
     peerDependencies:
       react: 18.3.1
       react-dom: 18.3.1
 
-  '@versini/ui-anchor@1.1.10':
-    resolution: {integrity: sha512-1cgvdTXmxxNZgSPtouEx9V5ekx1U/97iH+lRjZ2k8ScBX/iHGCnRRa1We2z23SxeAS07FNU7dLA5/NFQhEAhKw==}
+  '@versini/ui-anchor@1.1.11':
+    resolution: {integrity: sha512-gf595MCwpX9Zdv9bgTL+uRPKXpE/j3xtdMILsCguZvBhXDV6W0ndJ4bQAgAE95b4a5Ttf7PGhVFTs3gPdD4cJA==}
     peerDependencies:
       react: ^18.3.1
       react-dom: ^18.3.1
 
-  '@versini/ui-button@1.1.10':
-    resolution: {integrity: sha512-XLzUq9N1Tp2r/W0BV1t+puZuZ8xpr79YdUBstsQUIq+YOn1z0ksB+KkhTC/hOIebN30rzaZia2u3039fK1c/iQ==}
+  '@versini/ui-button@1.1.11':
+    resolution: {integrity: sha512-2hxESoGZMCdaw1mthftBtZbHwt/3m9Dltxl4IywI93Y7zsQB8ruPke/DTXux7/R8Cspl0ShSVmbQb0INtvzYzw==}
     peerDependencies:
       react: ^18.3.1
       react-dom: ^18.3.1
 
-  '@versini/ui-card@1.0.9':
-    resolution: {integrity: sha512-oWpqI79zUpJYnqx655sc8uLf4jkeBuvHluPqXiokQcnpcqoCp+K6vP/+xpr2Xjg9KzT3BekNPGdQL44PQYXC+w==}
+  '@versini/ui-card@1.0.10':
+    resolution: {integrity: sha512-aHh0zeEzs7vAnyM6+zFJzsiqoAv3YGiloCKBpWmmbyWeQo2gRRnzQvqfKQiImBT0wRltuHykq42+lUPP4vzm2g==}
     peerDependencies:
       react: ^18.3.1
       react-dom: ^18.3.1
 
-  '@versini/ui-footer@1.0.8':
-    resolution: {integrity: sha512-/2vyoHugkk8xiwg0VuscRoRbJ77B8rKp2vMHsSYkUaSkgktUaaTbzQaWFz69Q6+4Kl8xUk8L4Xwsf0i7YtkJzA==}
+  '@versini/ui-footer@1.0.9':
+    resolution: {integrity: sha512-Pj+IAEJgIATCX89nNEX6F3rSwK7dJvMVl/tzWiXQlk3YHzhRN/XguOMnhObJgeQaXDhqoC3pYqjQanibHW+73g==}
     peerDependencies:
       react: ^18.3.1
       react-dom: ^18.3.1
 
-  '@versini/ui-header@1.1.0':
-    resolution: {integrity: sha512-juewJKCZocK4ScZF1+2U/VK5pDaO6QforVdqO7Sd8G7Qqhz3O22R4zDoIkLksad+vV9UTCU/ZcwT308rBh5hrg==}
+  '@versini/ui-header@1.1.1':
+    resolution: {integrity: sha512-P1W0H/IMNbPfFA7ixX2ERyYdCIzLiwE81Dg1IdxOgJl7Flj7tL+ptKfqIG2zy9UCCQGjbnydbgWJlgXBkWGHSQ==}
     peerDependencies:
       react: ^18.3.1
       react-dom: ^18.3.1
@@ -1519,65 +1519,65 @@ packages:
       react: ^18.3.1
       react-dom: ^18.3.1
 
-  '@versini/ui-icons@1.15.1':
-    resolution: {integrity: sha512-/x2RBD3SfZbe1WyzCxxX3xhIaf7WUwMB9FkwLdFa1KtbLVTIIbd0ySNHwou1T+T6ivbndAAZKId39gx6RE1+oA==}
+  '@versini/ui-icons@1.15.2':
+    resolution: {integrity: sha512-y7fKnOztKgK7Irwvx7RlhVlqNY2FKIzeoRKpgcvtbjnYQIGGiytQMuCJW5OQ6ki9NNtwk7nbwluh3njj+GMhSQ==}
     peerDependencies:
       react: ^18.3.1
       react-dom: ^18.3.1
 
-  '@versini/ui-main@1.0.8':
-    resolution: {integrity: sha512-4Vf/D2jhZId+5nQAACw0/vCPwBCeybnGe49mqOhblF/0nfMugk5iRBog4BaSBZvYae0s5u0iU4x7dPJBdlbkKA==}
+  '@versini/ui-main@1.0.9':
+    resolution: {integrity: sha512-GphIiDewtf8k2EnCCzYv4HckyuBipEiD0n2pNO7LWXwdKjLKHJhNguVfBOIWjyoNm9lUF8OcmmhQ+y3KbYqOZA==}
     peerDependencies:
       react: ^18.3.1
       react-dom: ^18.3.1
 
-  '@versini/ui-menu@1.1.0':
-    resolution: {integrity: sha512-YKtHQM8HoN2WBYl1n/tyQl3ysaYfXmCZeG8ThAFPwUwSB1wsJ7q6RLcV0Lem16CPuoh4Y7Y6iSXO2726ytUQaQ==}
+  '@versini/ui-menu@1.1.1':
+    resolution: {integrity: sha512-UDox+XkLFR4zOHWjy0cZavbWfEwzSyZ9tE36uasqO8+bUxOVfI1ZztCEAe5+jyji16fZYn3fdmGouPwXdaJjZg==}
     peerDependencies:
       react: ^18.3.1
       react-dom: ^18.3.1
 
-  '@versini/ui-panel@1.0.14':
-    resolution: {integrity: sha512-c2fIZ6kWPKqETCOZEW0V//ekQpBJtrteZEnPmNlIEDHavn7MMcAYEuGbfw+wVrPMKSsz04YmxfM8/I/CY+xvyQ==}
+  '@versini/ui-panel@1.0.15':
+    resolution: {integrity: sha512-nLClwXlgRSa4FXpQ4ooU3xTCFiSkzRlvlQvoXs9yWDj/GlUUTQEGj7Q5zoVYt33EbyLGcak+RQt0a+YaVjJUig==}
     peerDependencies:
       react: ^18.3.1
       react-dom: ^18.3.1
 
-  '@versini/ui-private@1.4.17':
-    resolution: {integrity: sha512-IYYrk2rsP1jlH6ktPUGDlTgxNXpbQ47wb5J90BZdsVS1tL05rsBH4hM4kxSMcnwIsp0cM5ZuogP6KT6ZNolEzQ==}
+  '@versini/ui-private@1.4.18':
+    resolution: {integrity: sha512-L7vjzTm09aFz9ae12Q9GiMA8Y+fye+mBLmPcmyEN8wYf0r/ScArU8/AaObcD6Gg81wlFeJgpNIeBhHs+CWu9SA==}
     peerDependencies:
       react: ^18.3.1
       react-dom: ^18.3.1
 
-  '@versini/ui-styles@1.11.0':
-    resolution: {integrity: sha512-p4SrXPNbhb7MD3ATCKpT6RU4OpD3laIJ3qn+Bzv/JlV+MsIcp+v0R8sDAmIuxBJLADHHvukaQ/O+/fPKQGmPFA==}
+  '@versini/ui-styles@1.11.1':
+    resolution: {integrity: sha512-LLp8q4uqrNhPobJrx7PCDY3z2uo7z9J3hNUpbhJEJkg+YD1jsnJHXRm4COW0SAyuwX5tyjA0q93ABAPOmLhpjg==}
 
-  '@versini/ui-system@1.4.19':
-    resolution: {integrity: sha512-2xuX85yzOFlQtb2d3+3PR28/DRWVNuu3pa9yQX1LEKYFOfM8h5BR5tF+R6XWnJ6jPw7ip4dxeRIkLwfyI9il9Q==}
+  '@versini/ui-system@1.4.20':
+    resolution: {integrity: sha512-Ny4df3XOlKK/hhICK+TxPqwJUgI7MeIVBDRNNvkh4ccENcR+k/lDdyunNJT8CbFRaEuZhYTwSk+qLtM/Rvzl8w==}
     peerDependencies:
       react: ^18.3.1
       react-dom: ^18.3.1
 
-  '@versini/ui-table@1.0.13':
-    resolution: {integrity: sha512-KVx3NdW7ZaMfytHlBOG2f+MlJVFmNe9dZxRefEMgnlrs2avsZzCL3+EdU9LI1Z7OtpXWdmD+PFhxhjdDn0czlg==}
+  '@versini/ui-table@1.1.0':
+    resolution: {integrity: sha512-TlAW4p/L0bpuWz60VpdP7Sk1MRAHuAI2gd+BFXDjhiav63oc6aXxwQhWeT6taGlFeMoJfmTWtKlIhzUwlMGvuA==}
     peerDependencies:
       react: ^18.3.1
       react-dom: ^18.3.1
 
-  '@versini/ui-textarea@1.0.8':
-    resolution: {integrity: sha512-8By+u03o/MmilCQIgkhUZ7PajCJmRg2pCxbdGm3bvSJ0r+3KgV5OLNhALp2urTVJuUa9Im9uKtlzkBjgCocpKA==}
+  '@versini/ui-textarea@1.0.9':
+    resolution: {integrity: sha512-Z3hkA33Q2bd657LatksOowPaU2MiHuPUj+U7Tl6MoPN0VgogAKuZX5wLau4zsXY0KOJ9t/1TsovGhFHNGeEydA==}
     peerDependencies:
       react: ^18.3.1
       react-dom: ^18.3.1
 
-  '@versini/ui-textinput@1.2.1':
-    resolution: {integrity: sha512-O3eTrJNSVpHXDXxcxXYBX1MsXCA0yhqI1vTG2pudSAkFZsBNYpcOcEBSMBkH+2rjJFSa3pJ2Rrp2Nsk9v17U7w==}
+  '@versini/ui-textinput@1.2.2':
+    resolution: {integrity: sha512-Qc8J5eCmrjmKkgmeZQiDxO05TAJOAaoI4lgeleo2krfTuMyvLZaxyY+XE8ZxKWYS3As2kQy7YKBCDcp7n0FIVA==}
     peerDependencies:
       react: ^18.3.1
       react-dom: ^18.3.1
 
-  '@versini/ui-togglegroup@1.1.0':
-    resolution: {integrity: sha512-jnzzjM9RRJ0je66xMD6Qh6Cj5uLKLJGZmmmyN0m38dMxqN8yX5vqSII1CyNfWHNqKcso+UGTh4xlfL/a+7hDdg==}
+  '@versini/ui-togglegroup@1.1.1':
+    resolution: {integrity: sha512-BxnT9tK9bT5+H8g9eIqA6tE4KbOiIV333Xn6+NQOte0DVT3RBQ8iwVio5eD7tPLrchPSeUjXKdGTwLURvs/nsA==}
     peerDependencies:
       react: ^18.3.1
       react-dom: ^18.3.1
@@ -3188,6 +3188,10 @@ packages:
     resolution: {integrity: sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==}
     hasBin: true
 
+  jiti@1.21.6:
+    resolution: {integrity: sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==}
+    hasBin: true
+
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
@@ -3911,6 +3915,9 @@ packages:
   picocolors@1.1.0:
     resolution: {integrity: sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==}
 
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
@@ -4012,12 +4019,22 @@ packages:
     peerDependencies:
       postcss: ^8.2.14
 
+  postcss-nested@6.2.0:
+    resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.2.14
+
   postcss-selector-parser@6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
     engines: {node: '>=4'}
 
   postcss-selector-parser@6.0.15:
     resolution: {integrity: sha512-rEYkQOMUCEMhsKbK66tbEU9QVIxbhN18YiniAwA7XQYTVBqrBy+P2p5JcdqsHgKM2zWylp8d7J6eszocfds5Sw==}
+    engines: {node: '>=4'}
+
+  postcss-selector-parser@6.1.2:
+    resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
     engines: {node: '>=4'}
 
   postcss-value-parser@4.2.0:
@@ -4170,15 +4187,15 @@ packages:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
 
-  react-router-dom@6.27.0:
-    resolution: {integrity: sha512-+bvtFWMC0DgAFrfKXKG9Fc+BcXWRUO1aJIihbB79xaeq0v5UzfvnM5houGUm1Y461WVRcgAQ+Clh5rdb1eCx4g==}
+  react-router-dom@6.28.0:
+    resolution: {integrity: sha512-kQ7Unsl5YdyOltsPGl31zOjLrDv+m2VcIEcIHqYYD3Lp0UppLjrzcfJqDJwXxFw3TH/yvapbnUvPlAj7Kx5nbg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  react-router@6.27.0:
-    resolution: {integrity: sha512-YA+HGZXz4jaAkVoYBE98VQl+nVzI+cVI2Oj/06F5ZM+0u3TgedN9Y9kmMRo2mnkSK2nCpNQn0DVob4HCsY/WLw==}
+  react-router@6.28.0:
+    resolution: {integrity: sha512-HrYdIFqdrnhDw0PqG/AKjAqEqM7AvxCz0DQ4h2W8k6nqmc5uRBYDag0SBxx9iYz5G8gnuNVLzUe13wl9eAsXXg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
@@ -4630,8 +4647,8 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
-  tailwindcss@3.4.14:
-    resolution: {integrity: sha512-IcSvOcTRcUtQQ7ILQL5quRDg7Xs93PdJEk1ZLbhhvJc7uj/OAhYOnruEiwnGgBvUtaUAJ8/mhSw1o8L2jCiENA==}
+  tailwindcss@3.4.15:
+    resolution: {integrity: sha512-r4MeXnfBmSOuKUWmXe6h2CcyfzJCEk4F0pptO5jlnYSIViUkVmsawj80N5h2lO3gwcmSb4n3PuN+e+GC1Guylw==}
     engines: {node: '>=14.0.0'}
     hasBin: true
 
@@ -5457,7 +5474,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@floating-ui/react@0.26.24(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@floating-ui/react@0.26.28(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/react-dom': 2.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@floating-ui/utils': 0.2.8
@@ -6085,7 +6102,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
 
-  '@remix-run/router@1.20.0': {}
+  '@remix-run/router@1.21.0': {}
 
   '@rollup/pluginutils@5.1.0(rollup@4.24.0)':
     dependencies:
@@ -6360,13 +6377,13 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@tailwindcss/typography@0.5.15(tailwindcss@3.4.13)':
+  '@tailwindcss/typography@0.5.15(tailwindcss@3.4.15)':
     dependencies:
       lodash.castarray: 4.4.0
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       postcss-selector-parser: 6.0.10
-      tailwindcss: 3.4.13
+      tailwindcss: 3.4.15
 
   '@testing-library/dom@10.4.0':
     dependencies:
@@ -6550,7 +6567,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       uuid: 10.0.0
 
-  '@versini/dev-dependencies-client@6.0.8(@microsoft/api-extractor@7.47.7(@types/node@22.7.5))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)(@types/node@22.7.5)(@types/react-dom@18.3.0)(@types/react@18.3.11)(encoding@0.1.13)(esbuild@0.23.0)(happy-dom@15.7.4)(jiti@1.21.0)(jsdom@25.0.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.31.4)(typescript@5.6.2)(yaml@2.5.0)':
+  '@versini/dev-dependencies-client@6.0.8(@microsoft/api-extractor@7.47.7(@types/node@22.7.5))(@swc/core@1.7.26(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)(@types/node@22.7.5)(@types/react-dom@18.3.0)(@types/react@18.3.11)(encoding@0.1.13)(esbuild@0.23.0)(happy-dom@15.7.4)(jiti@1.21.6)(jsdom@25.0.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(terser@5.31.4)(typescript@5.6.2)(yaml@2.5.0)':
     dependencies:
       '@rsbuild/core': 1.0.11
       '@rsbuild/plugin-react': 1.0.3(@rsbuild/core@1.0.11)
@@ -6577,7 +6594,7 @@ snapshots:
       rimraf: 6.0.1
       rollup: 4.24.0
       tailwindcss: 3.4.13
-      tsup: 8.3.0(@microsoft/api-extractor@7.47.7(@types/node@22.7.5))(@swc/core@1.7.26(@swc/helpers@0.5.13))(jiti@1.21.0)(postcss@8.4.47)(typescript@5.6.2)(yaml@2.5.0)
+      tsup: 8.3.0(@microsoft/api-extractor@7.47.7(@types/node@22.7.5))(@swc/core@1.7.26(@swc/helpers@0.5.13))(jiti@1.21.6)(postcss@8.4.47)(typescript@5.6.2)(yaml@2.5.0)
       vite: 5.4.8(@types/node@22.7.5)(terser@5.31.4)
       vite-plugin-dts: 4.2.3(@types/node@22.7.5)(rollup@4.24.0)(typescript@5.6.2)(vite@5.4.8(@types/node@22.7.5)(terser@5.31.4))
       vite-plugin-lib-inject-css: 2.1.1(vite@5.4.8(@types/node@22.7.5)(terser@5.31.4))
@@ -6670,67 +6687,67 @@ snapshots:
       '@types/uuid': 10.0.0
       '@types/yargs': 17.0.33
 
-  '@versini/sassysaint@5.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@versini/sassysaint@5.3.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@versini/ui-hooks': 4.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      tailwindcss: 3.4.14
+      tailwindcss: 3.4.15
     transitivePeerDependencies:
       - ts-node
 
-  '@versini/ui-anchor@1.1.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@versini/ui-anchor@1.1.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@tailwindcss/typography': 0.5.15(tailwindcss@3.4.13)
-      '@versini/ui-button': 1.1.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tailwindcss/typography': 0.5.15(tailwindcss@3.4.15)
+      '@versini/ui-button': 1.1.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      tailwindcss: 3.4.13
+      tailwindcss: 3.4.15
     transitivePeerDependencies:
       - ts-node
 
-  '@versini/ui-button@1.1.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@versini/ui-button@1.1.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@tailwindcss/typography': 0.5.15(tailwindcss@3.4.13)
-      '@versini/ui-private': 1.4.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tailwindcss/typography': 0.5.15(tailwindcss@3.4.15)
+      '@versini/ui-private': 1.4.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      tailwindcss: 3.4.13
+      tailwindcss: 3.4.15
     transitivePeerDependencies:
       - ts-node
 
-  '@versini/ui-card@1.0.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@versini/ui-card@1.0.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@tailwindcss/typography': 0.5.15(tailwindcss@3.4.13)
+      '@tailwindcss/typography': 0.5.15(tailwindcss@3.4.15)
       '@versini/ui-hooks': 4.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@versini/ui-private': 1.4.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@versini/ui-private': 1.4.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      tailwindcss: 3.4.13
+      tailwindcss: 3.4.15
     transitivePeerDependencies:
       - ts-node
 
-  '@versini/ui-footer@1.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@versini/ui-footer@1.0.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@tailwindcss/typography': 0.5.15(tailwindcss@3.4.13)
-      '@versini/ui-private': 1.4.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tailwindcss/typography': 0.5.15(tailwindcss@3.4.15)
+      '@versini/ui-private': 1.4.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      tailwindcss: 3.4.13
+      tailwindcss: 3.4.15
     transitivePeerDependencies:
       - ts-node
 
-  '@versini/ui-header@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@versini/ui-header@1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@tailwindcss/typography': 0.5.15(tailwindcss@3.4.13)
-      '@versini/ui-private': 1.4.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tailwindcss/typography': 0.5.15(tailwindcss@3.4.15)
+      '@versini/ui-private': 1.4.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      tailwindcss: 3.4.13
+      tailwindcss: 3.4.15
     transitivePeerDependencies:
       - ts-node
 
@@ -6744,117 +6761,117 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@versini/ui-icons@1.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@versini/ui-icons@1.15.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@versini/ui-private': 1.4.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@versini/ui-private': 1.4.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@versini/ui-main@1.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@versini/ui-main@1.0.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@tailwindcss/typography': 0.5.15(tailwindcss@3.4.13)
-      '@versini/ui-private': 1.4.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tailwindcss/typography': 0.5.15(tailwindcss@3.4.15)
+      '@versini/ui-private': 1.4.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      tailwindcss: 3.4.13
+      tailwindcss: 3.4.15
     transitivePeerDependencies:
       - ts-node
 
-  '@versini/ui-menu@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@versini/ui-menu@1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@floating-ui/react': 0.26.24(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@tailwindcss/typography': 0.5.15(tailwindcss@3.4.13)
+      '@floating-ui/react': 0.26.28(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tailwindcss/typography': 0.5.15(tailwindcss@3.4.15)
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      tailwindcss: 3.4.13
+      tailwindcss: 3.4.15
     transitivePeerDependencies:
       - ts-node
 
-  '@versini/ui-panel@1.0.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@versini/ui-panel@1.0.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@tailwindcss/typography': 0.5.15(tailwindcss@3.4.13)
-      '@versini/ui-button': 1.1.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@versini/ui-icons': 1.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@versini/ui-private': 1.4.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tailwindcss/typography': 0.5.15(tailwindcss@3.4.15)
+      '@versini/ui-button': 1.1.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@versini/ui-icons': 1.15.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@versini/ui-private': 1.4.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      tailwindcss: 3.4.13
+      tailwindcss: 3.4.15
     transitivePeerDependencies:
       - ts-node
 
-  '@versini/ui-private@1.4.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@versini/ui-private@1.4.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@floating-ui/react': 0.26.24(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/react': 0.26.28(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@versini/ui-styles@1.11.0':
+  '@versini/ui-styles@1.11.1':
     dependencies:
-      '@tailwindcss/typography': 0.5.15(tailwindcss@3.4.13)
+      '@tailwindcss/typography': 0.5.15(tailwindcss@3.4.15)
       culori: 4.0.1
-      tailwindcss: 3.4.13
+      tailwindcss: 3.4.15
     transitivePeerDependencies:
       - ts-node
 
-  '@versini/ui-system@1.4.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@versini/ui-system@1.4.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@versini/ui-private': 1.4.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@versini/ui-private': 1.4.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      tailwindcss: 3.4.13
+      tailwindcss: 3.4.15
     transitivePeerDependencies:
       - ts-node
 
-  '@versini/ui-table@1.0.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@versini/ui-table@1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@tailwindcss/typography': 0.5.15(tailwindcss@3.4.13)
-      '@versini/ui-button': 1.1.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@versini/ui-icons': 1.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@versini/ui-private': 1.4.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tailwindcss/typography': 0.5.15(tailwindcss@3.4.15)
+      '@versini/ui-button': 1.1.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@versini/ui-icons': 1.15.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@versini/ui-private': 1.4.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      tailwindcss: 3.4.13
+      tailwindcss: 3.4.15
     transitivePeerDependencies:
       - ts-node
 
-  '@versini/ui-textarea@1.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@versini/ui-textarea@1.0.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@tailwindcss/typography': 0.5.15(tailwindcss@3.4.13)
+      '@tailwindcss/typography': 0.5.15(tailwindcss@3.4.15)
       '@versini/ui-hooks': 4.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@versini/ui-private': 1.4.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@versini/ui-private': 1.4.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      tailwindcss: 3.4.13
+      tailwindcss: 3.4.15
     transitivePeerDependencies:
       - ts-node
 
-  '@versini/ui-textinput@1.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@versini/ui-textinput@1.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@tailwindcss/typography': 0.5.15(tailwindcss@3.4.13)
+      '@tailwindcss/typography': 0.5.15(tailwindcss@3.4.15)
       '@versini/ui-hooks': 4.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@versini/ui-private': 1.4.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@versini/ui-private': 1.4.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      tailwindcss: 3.4.13
+      tailwindcss: 3.4.15
     transitivePeerDependencies:
       - ts-node
 
-  '@versini/ui-togglegroup@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@versini/ui-togglegroup@1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-toggle-group': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@tailwindcss/typography': 0.5.15(tailwindcss@3.4.13)
-      '@versini/ui-private': 1.4.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tailwindcss/typography': 0.5.15(tailwindcss@3.4.15)
+      '@versini/ui-private': 1.4.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      tailwindcss: 3.4.13
+      tailwindcss: 3.4.15
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -8631,6 +8648,8 @@ snapshots:
 
   jiti@1.21.0: {}
 
+  jiti@1.21.6: {}
+
   jju@1.4.0: {}
 
   jose@5.9.3: {}
@@ -9548,6 +9567,8 @@ snapshots:
 
   picocolors@1.1.0: {}
 
+  picocolors@1.1.1: {}
+
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
@@ -9602,11 +9623,11 @@ snapshots:
     optionalDependencies:
       postcss: 8.4.47
 
-  postcss-load-config@6.0.1(jiti@1.21.0)(postcss@8.4.47)(yaml@2.5.0):
+  postcss-load-config@6.0.1(jiti@1.21.6)(postcss@8.4.47)(yaml@2.5.0):
     dependencies:
       lilconfig: 3.1.2
     optionalDependencies:
-      jiti: 1.21.0
+      jiti: 1.21.6
       postcss: 8.4.47
       yaml: 2.5.0
 
@@ -9615,12 +9636,22 @@ snapshots:
       postcss: 8.4.47
       postcss-selector-parser: 6.0.15
 
+  postcss-nested@6.2.0(postcss@8.4.47):
+    dependencies:
+      postcss: 8.4.47
+      postcss-selector-parser: 6.1.2
+
   postcss-selector-parser@6.0.10:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
   postcss-selector-parser@6.0.15:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
+  postcss-selector-parser@6.1.2:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
@@ -9702,16 +9733,16 @@ snapshots:
 
   react-refresh@0.14.2: {}
 
-  react-router-dom@6.27.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router-dom@6.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.20.0
+      '@remix-run/router': 1.21.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-router: 6.27.0(react@18.3.1)
+      react-router: 6.28.0(react@18.3.1)
 
-  react-router@6.27.0(react@18.3.1):
+  react-router@6.28.0(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.20.0
+      '@remix-run/router': 1.21.0
       react: 18.3.1
 
   react@18.3.1:
@@ -10227,7 +10258,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tailwindcss@3.4.14:
+  tailwindcss@3.4.15:
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -10237,18 +10268,18 @@ snapshots:
       fast-glob: 3.3.2
       glob-parent: 6.0.2
       is-glob: 4.0.3
-      jiti: 1.21.0
+      jiti: 1.21.6
       lilconfig: 2.1.0
       micromatch: 4.0.8
       normalize-path: 3.0.0
       object-hash: 3.0.0
-      picocolors: 1.1.0
+      picocolors: 1.1.1
       postcss: 8.4.47
       postcss-import: 15.1.0(postcss@8.4.47)
       postcss-js: 4.0.1(postcss@8.4.47)
       postcss-load-config: 4.0.2(postcss@8.4.47)
-      postcss-nested: 6.0.1(postcss@8.4.47)
-      postcss-selector-parser: 6.0.15
+      postcss-nested: 6.2.0(postcss@8.4.47)
+      postcss-selector-parser: 6.1.2
       resolve: 1.22.8
       sucrase: 3.35.0
     transitivePeerDependencies:
@@ -10388,7 +10419,7 @@ snapshots:
 
   tslib@2.6.2: {}
 
-  tsup@8.3.0(@microsoft/api-extractor@7.47.7(@types/node@22.7.5))(@swc/core@1.7.26(@swc/helpers@0.5.13))(jiti@1.21.0)(postcss@8.4.47)(typescript@5.6.2)(yaml@2.5.0):
+  tsup@8.3.0(@microsoft/api-extractor@7.47.7(@types/node@22.7.5))(@swc/core@1.7.26(@swc/helpers@0.5.13))(jiti@1.21.6)(postcss@8.4.47)(typescript@5.6.2)(yaml@2.5.0):
     dependencies:
       bundle-require: 5.0.0(esbuild@0.23.0)
       cac: 6.7.14
@@ -10399,7 +10430,7 @@ snapshots:
       execa: 5.1.1
       joycon: 3.1.1
       picocolors: 1.1.0
-      postcss-load-config: 6.0.1(jiti@1.21.0)(postcss@8.4.47)(yaml@2.5.0)
+      postcss-load-config: 6.0.1(jiti@1.21.6)(postcss@8.4.47)(yaml@2.5.0)
       resolve-from: 5.0.0
       rollup: 4.24.0
       source-map: 0.8.0-beta.0


### PR DESCRIPTION
This pull request includes several updates to dependencies in various files across the project. The changes are mainly focused on updating versions of dependencies in `package.json`, `packages/client/package.json`, and `pnpm-lock.yaml`.

Dependency updates:

* Updated `pnpm` package manager version from `9.12.2` to `9.13.2` in `package.json`.
* Updated multiple `@versini/ui-*` dependencies to their latest versions in `packages/client/package.json`.
* Updated `@floating-ui/react` from `0.26.24` to `0.26.28`, `@remix-run/router` from `1.20.0` to `1.21.0`, and `tailwindcss` from `3.4.14` to `3.4.15` in `pnpm-lock.yaml`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL539-R540) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL987-R988) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4633-R4651)

Additional changes in `pnpm-lock.yaml`:

* Added new resolution for `jiti@1.21.6` and `picocolors@1.1.1`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3191-R3194) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3918-R3920)
* Added new resolution for `postcss-nested@6.2.0` and `postcss-selector-parser@6.1.2`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4022-R4027) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4036-R4039)