### PR TITLE
fix: search string not reset when switching between shortcuts and chat

### DIFF
--- a/packages/client/src/modules/Layout/Root.tsx
+++ b/packages/client/src/modules/Layout/Root.tsx
@@ -100,6 +100,15 @@ export const Root = () => {
 		}
 	}, [isShortcuts, state]);
 
+	/**
+	 * Reset the search string when the user switches between shortcuts and chat.
+	 */
+	useEffect(() => {
+		if (!isShortcuts && searchString !== "") {
+			setSearchString("");
+		}
+	}, [isShortcuts, searchString]);
+
 	return (
 		<>
 			<Header mode="dark" sticky>


### PR DESCRIPTION
This pull request includes a change to the `Root` component in `packages/client/src/modules/Layout/Root.tsx`. The change ensures that the search string is reset when the user switches between shortcuts and chat.

* [`packages/client/src/modules/Layout/Root.tsx`](diffhunk://#diff-db9ac5bfbb69cd5fe27716908b75de7374775a26ea8b9325646973c38819c387R103-R111): Added a `useEffect` hook to reset the search string when the `isShortcuts` state changes and the search string is not empty.