### PR TITLE
fix: bump non-breaking dependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,5 @@
 		"@versini/dev-dependencies-client": "6.0.8",
 		"@versini/dev-dependencies-types": "1.3.10"
 	},
-	"packageManager": "pnpm@9.13.2+sha512.88c9c3864450350e65a33587ab801acf946d7c814ed1134da4a924f6df5a2120fd36b46aab68f7cd1d413149112d53c7db3a4136624cfd00ff1846a0c6cef48a"
+	"packageManager": "pnpm@9.14.2+sha512.6e2baf77d06b9362294152c851c4f278ede37ab1eba3a55fda317a4a17b209f4dbb973fb250a77abc463a341fcb1f17f17cfa24091c4eb319cda0d9b84278387"
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -27,7 +27,7 @@
 	},
 	"dependencies": {
 		"@versini/auth-provider": "7.3.3",
-		"@versini/sassysaint": "5.3.7",
+		"@versini/sassysaint": "5.3.8",
 		"@versini/ui-anchor": "1.1.11",
 		"@versini/ui-button": "1.1.11",
 		"@versini/ui-card": "1.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: 7.3.3
         version: 7.3.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/sassysaint':
-        specifier: 5.3.7
-        version: 5.3.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 5.3.8
+        version: 5.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@versini/ui-anchor':
         specifier: 1.1.11
         version: 1.1.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1471,8 +1471,8 @@ packages:
   '@versini/dev-dependencies-types@1.3.10':
     resolution: {integrity: sha512-/b709s6yM6YGdkRX1UaPM3GHUuqhb35kEoVrprzx+dWDKxpKitRjE6na+yBj/AUHG/9UFk42QJolV031DRTq/A==}
 
-  '@versini/sassysaint@5.3.7':
-    resolution: {integrity: sha512-oOkcrkoUkjVUVq1j9Z7ukDEPjgylbqgqILsHNuPMzndhIsghLq0zK7YLQprFzVoSoVCkEusMmJfme6d46gcTpA==}
+  '@versini/sassysaint@5.3.8':
+    resolution: {integrity: sha512-EKZ4d7G7n/0QW5X3cJCHd3/MEI4hBUsTTCgt78vyD0Ux4eYVBqMylbzpAjVEjP+IbHgvAxSttDAbmr5TLyXGsw==}
     peerDependencies:
       react: 18.3.1
       react-dom: 18.3.1
@@ -6687,7 +6687,7 @@ snapshots:
       '@types/uuid': 10.0.0
       '@types/yargs': 17.0.33
 
-  '@versini/sassysaint@5.3.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@versini/sassysaint@5.3.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@versini/ui-hooks': 4.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1


### PR DESCRIPTION
This pull request includes updates to several dependencies in the project. The most significant changes involve updating the `@versini/sassysaint` package and the `pnpm` package manager version.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L17-R17): Updated `pnpm` package manager from version `9.13.2` to `9.14.2`.
* [`packages/client/package.json`](diffhunk://#diff-26d3d28d31824ef26252df77cca08d24faea8451cb8fd3ffee2000f9e496daa0L30-R30): Updated `@versini/sassysaint` dependency from version `5.3.7` to `5.3.8`.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL27-R28): Updated `@versini/sassysaint` version references from `5.3.7` to `5.3.8` in multiple sections including `importers`, `packages`, and `snapshots`. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL27-R28) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1474-R1475) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6690-R6690)