### PR TITLE
feat: collapse editable content when global edit mode is false

### DIFF
--- a/packages/client/src/modules/App/reducer.ts
+++ b/packages/client/src/modules/App/reducer.ts
@@ -39,10 +39,14 @@ export const reducer = (state: StateProps, action: ActionProps) => {
 	}
 
 	if (action?.type === ACTION_SET_EDIT_MODE) {
+		/**
+		 * If the edit mode is disabled, reset the edit sections.
+		 */
+		const editSections = action.payload.editMode ? state.editSections : false;
 		return {
 			editMode: action.payload.editMode,
 
-			editSections: state.editSections,
+			editSections,
 			sections: state.sections,
 			status: state.status,
 		};

--- a/packages/client/src/modules/Shortcuts/Shortcuts.tsx
+++ b/packages/client/src/modules/Shortcuts/Shortcuts.tsx
@@ -20,7 +20,7 @@ import {
 } from "@versini/ui-table";
 import { TextArea } from "@versini/ui-textarea";
 import { TextInput } from "@versini/ui-textinput";
-import { useContext, useRef, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 
 import { CARD_SECTION, CARD_SECTION_VISIBLE } from "../../common/constants";
 import {
@@ -41,6 +41,15 @@ export const Shortcuts = () => {
 	const sectionWithShortcutRef = useRef<SectionProps | null>(null);
 
 	const { getAccessToken } = useAuth();
+
+	/**
+	 * Reset the editable section when the edit mode is disabled.
+	 */
+	useEffect(() => {
+		if (!state.editMode) {
+			setEditable(null);
+		}
+	}, [state]);
 
 	return state && state?.sections?.length > 0 ? (
 		<>


### PR DESCRIPTION
This pull request includes changes to improve the handling of edit mode and reset editable sections when the edit mode is disabled. The most important changes include updating the reducer to reset edit sections and adding a `useEffect` hook to manage the editable state in the `Shortcuts` component.

Changes to edit mode handling:

* [`packages/client/src/modules/App/reducer.ts`](diffhunk://#diff-fef1866f1ae396b98739e4f703e3cd9984d1f4b47681b07fb03880e4736996dcR42-R49): Updated the reducer to reset `editSections` when the edit mode is disabled.

Enhancements to `Shortcuts` component:

* [`packages/client/src/modules/Shortcuts/Shortcuts.tsx`](diffhunk://#diff-296cf81685f56474e8dfdebf504b7e68f6d23741ed688fdc58c6ea8bfe0a6bf4R45-R53): Added `useEffect` hook to reset the editable section when the edit mode is disabled.
* [`packages/client/src/modules/Shortcuts/Shortcuts.tsx`](diffhunk://#diff-296cf81685f56474e8dfdebf504b7e68f6d23741ed688fdc58c6ea8bfe0a6bf4L23-R23): Imported `useEffect` to support the new hook.