### PR TITLE
fix: bump uuid to latest release

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -46,6 +46,6 @@
 		"react": "18.3.1",
 		"react-dom": "18.3.1",
 		"react-router-dom": "6.28.0",
-		"uuid": "10.0.0"
+		"uuid": "11.0.3"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
         specifier: 6.28.0
         version: 6.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       uuid:
-        specifier: 10.0.0
-        version: 10.0.0
+        specifier: 11.0.3
+        version: 11.0.3
     devDependencies:
       '@versini/ui-styles':
         specifier: 1.11.1
@@ -4934,6 +4934,10 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
+
+  uuid@11.0.3:
+    resolution: {integrity: sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==}
     hasBin: true
 
   validate-npm-package-license@3.0.4:
@@ -10553,6 +10557,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@10.0.0: {}
+
+  uuid@11.0.3: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:


### PR DESCRIPTION
This pull request includes updates to the `uuid` package version across multiple files to ensure consistency and compatibility.

Dependency updates:

* [`packages/client/package.json`](diffhunk://#diff-26d3d28d31824ef26252df77cca08d24faea8451cb8fd3ffee2000f9e496daa0L49-R49): Updated the `uuid` package version from `10.0.0` to `11.0.3`.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL84-R85): Updated the `uuid` package version from `10.0.0` to `11.0.3` in the `importers` section.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4939-R4942): Added the resolution for `uuid@11.0.3` in the `packages` section.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR10561-R10562): Added `uuid@11.0.3` entry in the `snapshots` section.